### PR TITLE
fix: correct reports directory in pages workflow

### DIFF
--- a/.github/workflows/irr.yml
+++ b/.github/workflows/irr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Prepare Pages content
         run: |
           mkdir -p _site
-          cp -r report/* _site/
+          cp -r reports/* _site/
           # Create index.html that redirects to the main report
           cat > _site/index.html << 'EOF'
           <!DOCTYPE html>
@@ -73,7 +73,7 @@ jobs:
           name: irr-results
           path: |
             data/processed/
-            report/
+            reports/
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to use `reports/` directory for generated files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68b63fec15348325941a61198b7a2ff8