### PR TITLE
Handle missing reports in workflow

### DIFF
--- a/.github/workflows/irr.yml
+++ b/.github/workflows/irr.yml
@@ -30,7 +30,9 @@ jobs:
       - name: Prepare Pages content
         run: |
           mkdir -p _site
-          cp -r reports/* _site/
+          if [ -d reports ]; then
+            cp -r reports/* _site/ 2>/dev/null || true
+          fi
           # Create index.html that redirects to the main report
           cat > _site/index.html << 'EOF'
           <!DOCTYPE html>
@@ -74,6 +76,7 @@ jobs:
           path: |
             data/processed/
             reports/
+          if-no-files-found: warn
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
- Copy report files to Pages output only if they exist
- Avoid failing artifact upload when no reports are produced

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b642c9fde08325b45862eb272d9a67